### PR TITLE
Add missing #include <cstddef> for std::size_t

### DIFF
--- a/lexertl/memory_file.hpp
+++ b/lexertl/memory_file.hpp
@@ -8,6 +8,8 @@
 #ifndef LEXERTL_MEMORY_FILE_H
 #define LEXERTL_MEMORY_FILE_H
 
+#include <cstddef>
+
 #ifdef __unix__
 #include <fcntl.h>
 #include <unistd.h>


### PR DESCRIPTION
as without the `cstddef` header compilation fails due to undefined type `std::size_t`.
